### PR TITLE
fix initial connect and 404 on /socket.io/socket.io.js

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -235,9 +235,9 @@ app.all('/v2/:respath?', function (req, res, next) {
 });
 app.use(express.staticCache());
 app.use(express.static(__dirname + STATIC_PATH));
-app.listen(config.port);
+server = app.listen(config.port);
 
-var websocket = socketio.listen(app);
+var websocket = socketio.listen(server);
 
 websocket.sockets.on('connection', function (client) {
     var self = client;


### PR DESCRIPTION
Before this change the initial page just sits at "Connecting…" and I get a 404 for /socket.io/socket.io.js.  I
tested with node 0.6.17 and node 0.8.0 and this change seems to fix it.
