### PR TITLE
Close all readers when main process got TERM signal

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -30,7 +30,10 @@ var cache = { js: {}, jsc: {}, less: {} };
     });
 
     // trap TERM signals and close all readers
-    process.on('SIGTERM', closeReaders)
+    process.on('SIGTERM', function() {
+        closeReaders();
+        process.exit(0);
+    });
 
 /* Misc helper funcs */
     function closeReaders() {


### PR DESCRIPTION
otherwise spawned ''tail -n 50 -F' processes keep running after the node is terminated. 
