### PR TITLE
update for expressjs >= 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,13 +26,16 @@
     }
 
   , "dependencies": {
-      "dateformat": ">=1.x"
-    , "less":       "1.1.x"
-    , "mime":       "1.2.x"
-    , "socket.io":  "0.8.x"
-    , "uglify-js":  "1.2.x"
-    , "validator":  "0.3.x"
-    , "express":    ">=2.5.x"
+      "dateformat":     ">=1.x"
+    , "less":           "1.1.x"
+    , "mime":           "1.2.x"
+    , "socket.io":      "0.8.x"
+    , "uglify-js":      "1.2.x"
+    , "validator":      "0.3.x"
+    , "express":        ">=4.0.x"
+    , "morgan":         "~1.0.0"
+    , "body-parser":    "~1.0.2"
+    , "errorhandler":   "~1.0.1"
   }
 
   , "engines": { "node": ">= 0.6.0" }

--- a/stream.js
+++ b/stream.js
@@ -1,13 +1,16 @@
-var fs          = require('fs');
-var qs          = require('querystring');
-var net         = require('net');
-var path        = require('path');
-var exec        = require("child_process").exec;
-var express     = require('express');
-var socketio    = require('socket.io');
-var less        = require('less');
-var uglify      = require('uglify-js');
-var LogReader   = require('./lib/logreader');
+var fs              = require('fs');
+var qs              = require('querystring');
+var net             = require('net');
+var path            = require('path');
+var exec            = require("child_process").exec;
+var express         = require('express');
+var socketio        = require('socket.io');
+var morgan          = require('morgan');
+var bodyParser      = require('body-parser');
+var errorhandler    = require('errorhandler');
+var less            = require('less');
+var uglify          = require('uglify-js');
+var LogReader       = require('./lib/logreader');
 
 var STATIC_PATH = '/static';
 
@@ -56,13 +59,13 @@ var cache = { js: {}, jsc: {}, less: {} };
         }
     }
 
-var app = express.createServer();
+var app = express();
 //Allow JSONP support
 app.enable("jsonp callback");
-app.use(express.logger());
-app.use(express.bodyParser());
+app.use(morgan());
+app.use(bodyParser());
 app.use(express.query());
-app.use(express.errorHandler({ dumpExceptions: true, showStack: true }));
+app.use(errorhandler({ dumpExceptions: true, showStack: true }));
 
 //IRCCat proxy
 app.post('/irccat', function (req, res, next) {
@@ -245,7 +248,7 @@ app.all('/v2/:respath?', function (req, res, next) {
         (qs.length ? '?' + qs.join('?') : '')
         );
 });
-app.use(express.staticCache());
+
 app.use(express.static(__dirname + STATIC_PATH));
 server = app.listen(config.port);
 


### PR DESCRIPTION
The current version in master does not work out of the box because `npm install` will install express 4.1.x and all the middleware stuff breaks. These changes fix it all so expressjs 4.0.0 through current will work.

Not sure if node 0.6.0 works, might want to bump that to 0.8.0 or even 0.10.0 in package.json, but that's probably neither here nor there.

The `staticCache` middleware is no longer supported in Express JS, so I took it out. I wouldn't be surprised if the static server caches by default or something, but if it doesn't and it's a big deal, should be easy enough to dial in https://github.com/isaacs/st or something similar.

I did not do crazy extensive testing and there are, alas, no pre-existing tests in the code base that I'm seeing, but hopefully these are straightforward enough that any problems should be evident...

