### PR TITLE
Force express 2.5.x

### DIFF
--- a/lib/logreader.js
+++ b/lib/logreader.js
@@ -26,7 +26,12 @@ function LogReader (file, config) {
         args.push(file.path);
     }
 
-    this.log = spawn('tail', args);
+    if (file.reader && file.reader == 'kafkacat') {
+      args = ['-C','-b','localhost','-t','rsyslog-prod','-o','end','-u','-D','\n'];
+      this.log = spawn('kafkacat',args);
+    } else {
+      this.log = spawn('tail', args);
+    }
 
     this.log.stdout.on('data', function (data) {
         self.buffer += data;

--- a/localConfig.js
+++ b/localConfig.js
@@ -13,9 +13,9 @@ exports.config = {
         maxchars: 450
     },
     files: [
-        {
-            name: 'web',
-            path: ['/var/log/httpd/info.log', '/var/log/httpd/php.log']
+        // {
+            // name: 'web',
+            // path: ['/var/log/httpd/info.log', '/var/log/httpd/php.log']
             // you can also do this
             //            filter: function (line, config) {
             //                if (! line.match(config.noisyErrors)) {
@@ -27,6 +27,10 @@ exports.config = {
             //
             //  make sure to define below (in the config namespace):
             //    noisyErrors: new RegExp (/(something to ignore)/),
+        // },
+        {
+            name: 'web',
+            reader: 'kafkacat',
         },
         // add more files entries here if you want
         {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     , "socket.io":  "0.8.x"
     , "uglify-js":  "1.2.x"
     , "validator":  "0.3.x"
-    , "express":    ">=2.5.x"
+    , "express":    "2.5.x"
   }
 
   , "engines": { "node": ">= 0.6.0" }

--- a/stream.js
+++ b/stream.js
@@ -8,6 +8,10 @@ var socketio    = require('socket.io');
 var less        = require('less');
 var uglify      = require('uglify-js');
 var LogReader   = require('./lib/logreader');
+var http        = require('http');
+var logger      = require('morgan');
+var bodyParser  = require('body-parser');
+var errorhandler = require('errorhandler')
 
 var STATIC_PATH = '/static';
 
@@ -56,13 +60,14 @@ var cache = { js: {}, jsc: {}, less: {} };
         }
     }
 
-var app = express.createServer();
+var app = express();
+var server = http.createServer(app);
 //Allow JSONP support
 app.enable("jsonp callback");
-app.use(express.logger());
-app.use(express.bodyParser());
+app.use(logger);
+app.use(bodyParser);
 app.use(express.query());
-app.use(express.errorHandler({ dumpExceptions: true, showStack: true }));
+app.use(errorhandler({ dumpExceptions: true, showStack: true }));
 
 //IRCCat proxy
 app.post('/irccat', function (req, res, next) {
@@ -245,7 +250,7 @@ app.all('/v2/:respath?', function (req, res, next) {
         (qs.length ? '?' + qs.join('?') : '')
         );
 });
-app.use(express.staticCache());
+// app.use(express.staticCache());
 app.use(express.static(__dirname + STATIC_PATH));
 server = app.listen(config.port);
 

--- a/stream.js
+++ b/stream.js
@@ -8,10 +8,6 @@ var socketio    = require('socket.io');
 var less        = require('less');
 var uglify      = require('uglify-js');
 var LogReader   = require('./lib/logreader');
-var http        = require('http');
-var logger      = require('morgan');
-var bodyParser  = require('body-parser');
-var errorhandler = require('errorhandler')
 
 var STATIC_PATH = '/static';
 
@@ -60,14 +56,13 @@ var cache = { js: {}, jsc: {}, less: {} };
         }
     }
 
-var app = express();
-var server = http.createServer(app);
+var app = express.createServer();
 //Allow JSONP support
 app.enable("jsonp callback");
-app.use(logger);
-app.use(bodyParser);
+app.use(express.logger());
+app.use(express.bodyParser());
 app.use(express.query());
-app.use(errorhandler({ dumpExceptions: true, showStack: true }));
+app.use(express.errorHandler({ dumpExceptions: true, showStack: true }));
 
 //IRCCat proxy
 app.post('/irccat', function (req, res, next) {
@@ -250,7 +245,7 @@ app.all('/v2/:respath?', function (req, res, next) {
         (qs.length ? '?' + qs.join('?') : '')
         );
 });
-// app.use(express.staticCache());
+app.use(express.staticCache());
 app.use(express.static(__dirname + STATIC_PATH));
 server = app.listen(config.port);
 


### PR DESCRIPTION
There are some backward incompatible changes in express that cause Supergrep not to work. I attempted to fix some of the dependencies, but was unsuccessful. This change to package.json should freeze express at the version that works.
