### PR TITLE
Change package.json to target an older version of Express (2.5.10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     , "socket.io":  "0.8.x"
     , "uglify-js":  "1.2.x"
     , "validator":  "0.3.x"
-    , "express":    ">=2.5.x"
+    , "express":    "2.5.10"
   }
 
   , "engines": { "node": ">= 0.6.0" }


### PR DESCRIPTION
Express has gone through a lot of changes since this project was last touched, and as such I wasn't able to immediately run it after a fresh `npm install`.

Express 2.5.10 is the last version of Express that has all of the features you are currently using, so targeting this version is the best fix if you don't plan on updating/rewriting the stuff that's been deprecated. 
