### PR TITLE
Make supergrep work with Express 4+

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,13 +26,16 @@
     }
 
   , "dependencies": {
-      "dateformat": ">=1.x"
-    , "less":       "1.1.x"
-    , "mime":       "1.2.x"
-    , "socket.io":  "0.8.x"
-    , "uglify-js":  "1.2.x"
-    , "validator":  "0.3.x"
-    , "express":    ">=2.5.x"
+      "body-parser":   "^1.5.2"
+    , "dateformat":    ">=1.x"
+    , "errorhandler":  "^1.1.1"
+    , "less":          "1.1.x"
+    , "mime":          "1.2.x"
+    , "morgan":        "^1.2.2"
+    , "socket.io":     "0.8.x"
+    , "uglify-js":     "1.2.x"
+    , "validator":     "0.3.x"
+    , "express":       ">=2.5.x"
   }
 
   , "engines": { "node": ">= 0.6.0" }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     , "socket.io":     "0.8.x"
     , "uglify-js":     "1.2.x"
     , "validator":     "0.3.x"
-    , "express":       ">=2.5.x"
+    , "express":       ">=4.0.0"
   }
 
   , "engines": { "node": ">= 0.6.0" }

--- a/stream.js
+++ b/stream.js
@@ -1,13 +1,16 @@
-var fs          = require('fs');
-var qs          = require('querystring');
-var net         = require('net');
-var path        = require('path');
-var exec        = require("child_process").exec;
-var express     = require('express');
-var socketio    = require('socket.io');
-var less        = require('less');
-var uglify      = require('uglify-js');
-var LogReader   = require('./lib/logreader');
+var bodyParser    = require('body-parser')
+var errorHandler  = require('errorhandler')
+var fs            = require('fs');
+var qs            = require('querystring');
+var net           = require('net');
+var path          =  require('path');
+var exec          = require("child_process").exec;
+var express       = require('express');
+var socketio      = require('socket.io');
+var logger        = require('morgan');
+var less          = require('less');
+var uglify        = require('uglify-js');
+var LogReader     = require('./lib/logreader');
 
 var STATIC_PATH = '/static';
 
@@ -56,13 +59,14 @@ var cache = { js: {}, jsc: {}, less: {} };
         }
     }
 
-var app = express.createServer();
+var app = express();
+
 //Allow JSONP support
 app.enable("jsonp callback");
-app.use(express.logger());
-app.use(express.bodyParser());
+app.use(logger('dev'));
+app.use(bodyParser.json());
 app.use(express.query());
-app.use(express.errorHandler({ dumpExceptions: true, showStack: true }));
+app.use(errorHandler({ dumpExceptions: true, showStack: true }))
 
 //IRCCat proxy
 app.post('/irccat', function (req, res, next) {
@@ -245,7 +249,6 @@ app.all('/v2/:respath?', function (req, res, next) {
         (qs.length ? '?' + qs.join('?') : '')
         );
 });
-app.use(express.staticCache());
 app.use(express.static(__dirname + STATIC_PATH));
 server = app.listen(config.port);
 


### PR DESCRIPTION
Express 4 removes all built-in middleware (except `express.static`) from its core [1]. This patch updates supergrep to play well with it. I've updated the minimum Express requirement in `package.json` but I'm not sure how versioning is handled for releases.

I know this project is archived, but... ¯\\_(ツ)_/¯

[1] https://expressjs.com/en/guide/migrating-4.html#core-changes